### PR TITLE
Add pip requirement to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - geopandas
   - matplotlib
   - pip:
-    -r file:requirements.txt
+    - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,5 @@ dependencies:
   - rasterio
   - geopandas
   - matplotlib
+  - pip:
+    -r file:requirements.txt


### PR DESCRIPTION
I remembered seeing this in a JupyterCon talk: [Best practices for managing Jupyter-based data science projects using Conda (+Pip)](https://cfp.jupytercon.com/2020/schedule/presentation/234/best-practices-for-managing-jupyter-based-data-science-projects-using-conda-pip/) by David R. Pugh.

Seems like image-building wizardry to me, but in my [last build](https://github.com/salvis2/icepyx-examples-image/runs/1288086504?check_suite_focus=true) on my fork, it picked up the three packages in `environment.yml`: `icepyx`, `contextily`, and `topohack` (search the second or third of those to find proof, `icepyx` appears very often since it is the name of the image).