### PR TITLE
Install icepyx and contextily from conda-forge instead of PyPI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,16 +2,16 @@ name: icepyx-examples-image
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
   - contextily
-  - numpy
-  - xarray
-  - pandas
+  - geopandas
   - h5py
   - icepyx
-  - rasterio
-  - geopandas
-  - matplotlib
   - lxml
+  - matplotlib
+  - numpy
+  - pandas
+  - python=3.9
+  - rasterio
+  - xarray
   - pip:
     - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - contextily
   - numpy
   - xarray
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - xarray
   - pandas
   - h5py
+  - icepyx
   - rasterio
   - geopandas
   - matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 git+https://github.com/ICESAT-2HackWeek/topohack.git#egg=topohack
-git+https://github.com/darribas/contextily.git#egg=contextily

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-git+https://github.com/icesat2py/icepyx.git@v0.3.1#egg=icepyx
 git+https://github.com/ICESAT-2HackWeek/topohack.git#egg=topohack
 git+https://github.com/darribas/contextily.git#egg=contextily


### PR DESCRIPTION
There are now updated conda-forge packages for `icepyx` and `contextily` at https://anaconda.org/conda-forge/icepyx and https://anaconda.org/conda-forge/contextily respectively so we might as well use them!

Also sorted the dependencies in the conda `environment.yml` file alphabetically, and bumped up the Python version from 3.7 to 3.9.